### PR TITLE
Libsystem: optimize memcpy.

### DIFF
--- a/kernel/.build.mk
+++ b/kernel/.build.mk
@@ -19,12 +19,25 @@ KERNEL_LIBRARIES_SOURCES = \
 	$(wildcard libraries/libsystem/process/*.c) \
 	$(wildcard libraries/libsystem/utils/*.c)
 
+KERNEL_LIBRARIES_ASSEMBLY_SOURCES = \
+	$(wildcard libraries/libfile/*.s) \
+	$(wildcard libraries/libjson/*.s) \
+	$(wildcard libraries/libmath/*.s) \
+	$(wildcard libraries/libmath/*/*.s) \
+	$(wildcard libraries/libsystem/*.s) \
+	$(wildcard libraries/libsystem/io/*.s) \
+	$(wildcard libraries/libsystem/unicode/*.s) \
+	$(wildcard libraries/libsystem/process/*.s) \
+	$(wildcard libraries/libsystem/utils/*.s)
+
+
 KERNEL_BINARY = $(BOOTROOT)/boot/kernel.bin
 
 KERNEL_OBJECTS = \
 	$(patsubst %.c, $(BUILD_DIRECTORY)/%.o, $(KERNEL_SOURCES)) \
 	$(patsubst %.s, $(BUILD_DIRECTORY)/%.s.o, $(KERNEL_ASSEMBLY_SOURCES)) \
-	$(patsubst libraries/%.c, $(BUILD_DIRECTORY)/kernel/%.o, $(KERNEL_LIBRARIES_SOURCES))
+	$(patsubst libraries/%.c, $(BUILD_DIRECTORY)/kernel/%.o, $(KERNEL_LIBRARIES_SOURCES)) \
+	$(patsubst libraries/%.s, $(BUILD_DIRECTORY)/kernel/%.s.o, $(KERNEL_LIBRARIES_ASSEMBLY_SOURCES))
 
 OBJECTS += $(KERNEL_OBJECTS)
 
@@ -32,6 +45,11 @@ $(BUILD_DIRECTORY)/kernel/%.o: libraries/%.c
 	$(DIRECTORY_GUARD)
 	@echo [KERNEL] [CC] $<
 	@$(CC) $(CFLAGS) -ffreestanding -nostdlib -c -o $@ $<
+
+$(BUILD_DIRECTORY)/kernel/%.s.o: libraries/%.s
+	$(DIRECTORY_GUARD)
+	@echo [KERNEL] [AS] $<
+	@$(AS) $(ASFLAGS) $^ -o $@
 
 $(BUILD_DIRECTORY)/kernel/%.o: kernel/%.c
 	$(DIRECTORY_GUARD)

--- a/libraries/libsystem/CString.c
+++ b/libraries/libsystem/CString.c
@@ -102,6 +102,8 @@ void *memmove(void *dest, const void *src, size_t n)
     return dest;
 }
 
+#if 0
+
 void *memcpy(void *s1, const void *s2, size_t n)
 {
     char *cdest;
@@ -126,6 +128,8 @@ void *memcpy(void *s1, const void *s2, size_t n)
 
     return s1;
 }
+
+#endif
 
 void *memset(void *str, int c, size_t n)
 {

--- a/libraries/libsystem/CStringAsm.s
+++ b/libraries/libsystem/CStringAsm.s
@@ -1,0 +1,135 @@
+global memcpy
+memcpy:
+    push ebp
+    mov ebp, esp
+
+    ; Save used registers
+    push edx
+    push ecx
+    push edi
+    push esi
+
+    ; Size
+    mov ecx, [ebp + 0x10]
+    ; If the size is zero, return
+    test ecx, ecx
+    jz .done
+    
+    ; Source pointer 
+    mov esi, [ebp + 0x0c]
+
+    ; Destination pointer
+    mov edi, [ebp + 0x08]
+
+    ; Check if esi and edi are valid
+    mov eax, edi
+    or eax, esi
+    jz .done
+
+    ; The returned value is the destination pointer
+    mov eax, edi
+
+    ; Check if the size is a tiny value
+    cmp ecx, 8
+    jle .small
+
+    ; If not, copy normally
+    jmp .copy
+
+.small:
+    cmp ecx, 1
+    je .n1
+    cmp ecx, 2
+    je .n2
+    cmp ecx, 3
+    je .n3
+    cmp ecx, 4
+    je .n4
+    cmp ecx, 5
+    je .n5
+    cmp ecx, 6
+    je .n6
+    cmp ecx, 7
+    je .n7
+    cmp ecx, 8
+    je .n8
+
+.n1: 
+    mov dl, [esi]
+    mov [edi], dl
+    jmp .done
+
+.n2: 
+    mov dx, [esi]
+    mov [edi], dx
+    jmp .done
+
+.n3: 
+    mov dx, [esi]
+    mov [edi], dx
+    mov dl, [esi + 2]
+    mov [edi + 2], dl
+    jmp .done
+
+.n4: 
+    mov edx, [esi]
+    mov [edi], edx
+    jmp .done
+
+.n5: 
+    mov edx, [esi]
+    mov [edi], edx
+    mov dl, [esi + 4]
+    mov [edi + 4], dl
+    jmp .done
+
+.n6: 
+    mov edx, [esi]
+    mov [edi], edx
+    mov dx, [esi + 4]
+    mov [edi + 4], dx
+    jmp .done
+
+.n7:
+    mov edx, [esi]
+    mov [edi], edx
+    mov dx, [esi + 4]
+    mov [edi + 4], dx
+    mov dl, [esi + 6]
+    mov [edi + 6], dl
+    jmp .done
+
+.n8:
+    mov edx, [esi]
+    mov [edi], edx
+    mov edx, [esi + 4]
+    mov [edi + 4], edx
+    jmp .done
+
+.copy:
+    mov edx, ecx
+    shr ecx, 2
+    rep movsd
+    mov ecx, edx
+    and ecx, 3
+
+    ; Copy the remaining bytes
+.padding:
+    test ecx, ecx
+    jz .done
+    mov dl, [esi]
+    mov [edi], dl
+    inc esi
+    inc edi
+    dec ecx
+    jmp .padding
+
+.done:
+    ; Restore the registers we fucked up :-)
+    pop esi
+    pop edi
+    pop ecx
+    pop edx
+
+    pop ebp
+    ret


### PR DESCRIPTION
I wrote an optimized version of the `memcpy` because it is a very essential function that may make a difference in the performance of the OS. Then I made some tests on user space that showed that the function was 1-5x faster than the current one, so it is quite a good improvement I guess. 
Hope it's useful and if you see something wrong or not conforming the style, please tell me so that I can fix it. 