### PR TITLE
Grub: add all_video module

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -2,12 +2,14 @@ set timeout=15
 set default=0
 
 menuentry "skiftOS" {
+   insmod all_video
    multiboot2 /boot/kernel.bin
    module2    /boot/ramdisk.tar ramdisk
    boot
 }
 
 menuentry "skiftOS (Multiboot v1)" {
+   insmod all_video
    multiboot /boot/kernel.bin
    module    /boot/ramdisk.tar ramdisk
    boot


### PR DESCRIPTION
Add `all_video` module to GRUB so that it works with UEFI systems.