### PR TITLE
libwidget: window maximize

### DIFF
--- a/libraries/libwidget/Event.h
+++ b/libraries/libwidget/Event.h
@@ -58,6 +58,7 @@ struct Event
 
         DISPLAY_SIZE_CHANGED,
 
+        WINDOW_MAXIMIZING,
         __COUNT,
     };
 

--- a/libraries/libwidget/Window.h
+++ b/libraries/libwidget/Window.h
@@ -26,12 +26,12 @@ struct Window
     bool focused;
     bool visible;
     bool is_dragging;
-
+    bool is_maximised;
     bool is_resizing;
     bool resize_vertical;
     bool resize_horizontal;
     Vec2i resize_begin;
-
+    Rectangle previous_bound; // used for maximize 
     WindowDestroyCallback destroy;
 
     CursorState cursor_state;
@@ -106,6 +106,7 @@ int window_backbuffer_handle(Window *window);
 Widget *window_root(Window *window);
 
 Widget *window_header(Window *window);
+
 
 void window_schedule_update(Window *window, Rectangle rectangle);
 


### PR DESCRIPTION
The top right "maximize" button can maximize the window !
at the moment there is a bug: windows are not redrawn when maximized
so the window has now 2 state :
maximized and not maximized
maximized window can't get moved or resized, they can only get de-maximized by pressing the maximize button (on the top right)
not maximized window are like classic window, they can be resized and moved
