### PR TITLE
Force IPv4 in the toolchain script

### DIFF
--- a/toolchain/build-it.sh
+++ b/toolchain/build-it.sh
@@ -43,13 +43,13 @@ source "$DIR/use-it.sh"
 
 pushd tarballs
     if [ ! -e "$BINUTILS_FILENAME" ]; then
-        wget "$BINUTILS_URL"
+        wget -4 "$BINUTILS_URL"
     else
         echo "Skipped downloading binutils"
     fi
 
     if [ ! -e "$GCC_FILENAME" ]; then
-        wget "$GCC_URL"
+        wget -4 "$GCC_URL"
     else
         echo "Skipped downloading gcc"
     fi


### PR DESCRIPTION
I bought a cheap Wi-Fi card which doesn't support IPv6 and because of this, wget simply hung up. I know it's my fault, but this doesn't change anything in terms of download speed.