### PR TITLE
file-manager: Update File Manager window title

### DIFF
--- a/applications/file-manager/main.cpp
+++ b/applications/file-manager/main.cpp
@@ -90,7 +90,7 @@ Window *file_explorer_window_create(const char *current_path)
     window_initialize(window, WINDOW_RESIZABLE);
 
     window->icon(Icon::get("folder"));
-    window->title("File Explorer");
+    window->title("File Manager");
     window->size(Vec2i(700, 500));
 
     Widget *root = window->root();


### PR DESCRIPTION
On my last pull request, I changed the name of File Explorer to File Manager. I forgot to change the window title. That's what I'm proposing.