### PR TITLE
Coreutils: simple check for the kill command to avoir kernel crashes

### DIFF
--- a/applications/coreutils/kill.cpp
+++ b/applications/coreutils/kill.cpp
@@ -6,7 +6,7 @@ int kill(const char *id)
 {
     int i = parse_uint_inline(PARSER_DECIMAL, id, -1);
 
-    if (i == -1)
+    if (i < 2)
     {
         return -1;
     }


### PR DESCRIPTION
I've noticed if you try to kill a kernel process (or anything below pid 2), it'll trigger a kernel panic. 
Here's a simple yet effective fix :wink: 