### PR TITLE
coreutils: add tac command

### DIFF
--- a/applications/coreutils/.build.mk
+++ b/applications/coreutils/.build.mk
@@ -23,6 +23,7 @@ UTILS = \
 	OPEN \
 	PANIC \
 	SYSFETCH \
+	TAC \
 	TOUCH \
 	UNLINK \
 	UPTIME \
@@ -107,6 +108,9 @@ RMDIR_NAME = rmdir
 
 SYSFETCH_LIBS =
 SYSFETCH_NAME = sysfetch
+
+TAC_LIBS = 
+TAC_NAME = tac
 
 TOUCH_LIBS =
 TOUCH_NAME = touch

--- a/applications/coreutils/tac.cpp
+++ b/applications/coreutils/tac.cpp
@@ -55,7 +55,10 @@ char *str_split(char *str, char *const sub_str)
 
     if (split)
     {
-        (*split) = 0;
+        if (*(split + strlen(sub_str)))
+        {
+            (*split) = 0;
+        }
         char *tmp = start;
         start = split + strlen(sub_str);
         return tmp;
@@ -78,7 +81,6 @@ Result tac(Stream *const input_stream)
     char buffer[1024];
     char *split = nullptr;
 
-    String s;
     StringBuilder temp;
     Vector<String> lines(20);
     if (!separator)
@@ -87,12 +89,11 @@ Result tac(Stream *const input_stream)
         strcpy(separator, "\n");
     }
 
-    while ((read = stream_read(input_stream, buffer, 1024)) != 0)
+    while ((read = stream_read(input_stream, buffer, 1024 - 1)) != 0)
     {
 
         buffer[read] = 0;
-        char *copy = strdup(buffer);
-        split = str_split(copy, separator);
+        split = str_split(buffer, separator);
         while (split != nullptr)
         {
             temp.append(split);

--- a/applications/coreutils/tac.cpp
+++ b/applications/coreutils/tac.cpp
@@ -1,0 +1,123 @@
+#include <libsystem/cmdline/CMDLine.h>
+#include <libsystem/io/Path.h>
+#include <libsystem/io/Stream.h>
+#include <libutils/String.h>
+#include <libutils/Vector.h>
+
+static bool before = false;
+static char *separator = nullptr;
+
+static const char *usages[] = {
+    "NAME...",
+    "[OPTION]... NAME...",
+    nullptr,
+};
+
+static CommandLineOption options[] = {
+    COMMANDLINE_OPT_HELP,
+    COMMANDLINE_OPT_STRING("separator", 's', separator,
+                           "choose the separator to be used instead of \\n",
+                           COMMANDLINE_NO_CALLBACK),
+    COMMANDLINE_OPT_BOOL("before", 'b', before,
+                         "attach the separator before instead of after the string",
+                         COMMANDLINE_NO_CALLBACK),
+    COMMANDLINE_OPT_END};
+
+static CommandLine cmdline = CMDLINE(
+    usages,
+    options,
+    "Concatenate and print lines of file(s) in reverse.",
+    "If no filename provided read from input stream");
+
+Result tac(const char *path)
+{
+
+    __cleanup(stream_cleanup) Stream *stream = stream_open(path, OPEN_READ);
+
+    if (handle_has_error(stream))
+    {
+        return handle_get_error(stream);
+    }
+    FileState stat = {};
+    stream_stat(stream, &stat);
+
+    size_t read;
+    char buffer[1024];
+    char sep = (separator == nullptr ? '\n' : separator[0]);
+
+    String s;
+    Vector<String> lines(20);
+
+    while ((read = stream_read(stream, &buffer, 1024)) != 0)
+    {
+        if (handle_has_error(stream))
+        {
+            return handle_get_error(stream);
+        }
+        String tmp(buffer, read);
+        s += tmp;
+    }
+
+    String *tmp = new String();
+    for (unsigned int i = 0; i < s.length(); ++i)
+    {
+        String tmp2(s[i]);
+        if (s[i] == sep || i == s.length() - 1)
+        {
+            if (!before)
+            {
+                *tmp += tmp2;
+            }
+            lines.push_back((*tmp));
+            delete tmp;
+            tmp = new String();
+            if (before)
+            {
+                *tmp += tmp2;
+            }
+        }
+        else
+        {
+            *tmp += tmp2;
+        }
+    }
+
+    for (unsigned int i = lines.count(); i >= 1; --i)
+    {
+        stream_write(out_stream, lines[i - 1].cstring(), lines[i - 1].length());
+        if (handle_has_error(out_stream))
+        {
+            return ERR_WRITE_STDOUT;
+        }
+    }
+
+    stream_flush(out_stream);
+
+    return SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    argc = cmdline_parse(&cmdline, argc, argv);
+
+    if (argc == 1)
+    {
+        /* TODO: Handle input from STDIN */
+        return PROCESS_SUCCESS;
+    }
+
+    Result result;
+
+    for (int i = 1; i < argc; i++)
+    {
+        result = tac(argv[i]);
+
+        if (result != SUCCESS)
+        {
+            stream_format(err_stream, "%s: %s: %s", argv[0], argv[i], get_result_description(result));
+            return PROCESS_FAILURE;
+        }
+    }
+
+    return PROCESS_SUCCESS;
+}

--- a/applications/coreutils/tac.cpp
+++ b/applications/coreutils/tac.cpp
@@ -39,37 +39,37 @@ char *str_split(char *str, char *const sub_str)
     Similar to strtok in string.h
     May not work as expected when the str contains '\0' in between
     */
-    static char *start = NULL;
+    static char *start = nullptr;
 
-    if(!start)
+    if (start == nullptr)
     {
         start = str;
     }
 
-    if(!*start)
+    if (!*start)
     {
-        return NULL;
+        return nullptr;
     }
 
     char *split = strstr(start, sub_str);
 
-    if(split)
+    if (split)
     {
         (*split) = 0;
         char *tmp = start;
         start = split + strlen(sub_str);
         return tmp;
     }
-    
+
     int len = strlen(start);
     if (len)
     {
         char *tmp = start;
         start += len;
-        return tmp;   
+        return tmp;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 Result tac(Stream *const input_stream)
@@ -89,32 +89,30 @@ Result tac(Stream *const input_stream)
 
     while ((read = stream_read(input_stream, buffer, 1024)) != 0)
     {
-        
+
         buffer[read] = 0;
         char *copy = strdup(buffer);
         split = str_split(copy, separator);
-        while (split != NULL)
+        while (split != nullptr)
         {
             temp.append(split);
-            if (!before)
+            split = str_split(NULL, separator);
+            if (!before && split)
             {
                 temp.append(separator);
             }
 
             lines.push_back(temp.finalize());
-            if (before)
+            if (before && split)
             {
                 temp.append(separator);
             }
-
-            split = str_split(NULL, separator);
         }
         if (temp.finalize().length())
         {
             lines.push_back(temp.finalize());
         }
     }
-
 
     for (size_t i = lines.count(); i > 0; i--)
     {


### PR DESCRIPTION
#162: Coreutils:  add **tac** command

The tac command displays the contents of the file in reverse order after splitting contents based on a separator(by defualt \n)

## Output
![Screenshot from 2020-10-18 13-32-51](https://user-images.githubusercontent.com/48756374/96361798-80219700-1146-11eb-9a1e-c2b7aea4dbfd.png)


## Output on ubuntu
![Screenshot from 2020-10-18 13-35-18](https://user-images.githubusercontent.com/48756374/96361842-cd056d80-1146-11eb-991d-69d88d2001ce.png)



## Known issues:
- Separator is assumed to be a single character
- Doesn't work on STDIN 