### PR TITLE
Added emplace_back to Vector class

### DIFF
--- a/libraries/libutils/Vector.h
+++ b/libraries/libutils/Vector.h
@@ -442,8 +442,8 @@ public:
     {
         grow();
         
-        new(&_storage[_size]) T(forward<Args>(args)...);
-        return _storage[_size++];
+        new(&_storage[_count]) T(forward<Args>(args)...);
+        return _storage[_count++];
     }
 
     void push_back_many(const Vector<T> &values)

--- a/libraries/libutils/Vector.h
+++ b/libraries/libutils/Vector.h
@@ -436,6 +436,15 @@ public:
     {
         return insert(_count, move(value));
     }
+    
+    template <typename... Args>
+    T& emplace_back(Args&&... args)
+    {
+        grow();
+        
+        new(&_storage[_size]) T(forward<Args>(args)...);
+        return _storage[_size++];
+    }
 
     void push_back_many(const Vector<T> &values)
     {


### PR DESCRIPTION
The `emplace_back` function constructs and adds an object to the end of a vector.