### PR TITLE
Removed IOAPIC address from parameters

### DIFF
--- a/architectures/x86_32/kernel/IOAPIC.h
+++ b/architectures/x86_32/kernel/IOAPIC.h
@@ -4,6 +4,6 @@
 
 void ioapic_found(uintptr_t address);
 
-uint32_t apic_read(void *ioapicaddr, uint32_t reg);
+uint32_t apic_read(uint32_t reg);
 
-void ioapic_write(void *ioapicaddr, uint32_t reg, uint32_t value);
+void ioapic_write(uint32_t reg, uint32_t value);


### PR DESCRIPTION
I've removed the IOAPIC address from the parameters of the read and write functions. These are not used in the source files, as they are provided as a global variable that is updated by using the found function.