### PR TITLE
libutils: add missing _start initialization

### DIFF
--- a/libraries/libutils/Slice.h
+++ b/libraries/libutils/Slice.h
@@ -36,6 +36,7 @@ public:
     {
         ref_if_not_null(_storage);
 
+        _start = _storage->start();
         _start = static_cast<const void *>(static_cast<const char *>(_start) + offset);
         _size = size;
     }


### PR DESCRIPTION
Would cause a page fault, due to invalid memory access