### PR TITLE
Update building.md

### DIFF
--- a/manual/00-meta/building.md
+++ b/manual/00-meta/building.md
@@ -93,7 +93,7 @@ Then for building the toolchain run the `build-it.sh` script
 
 ```sh
 ## Build the tool chain
-$ toolchain/build-it.sh
+$ sh toolchain/build-it.sh
 
 ## Then wait for completion
 ```


### PR DESCRIPTION
Add sh prefix to command due to some distro's not properly recognizing scripts without chmod'ing it or using the sh prefix.