### PR TITLE
hjert: Gdt support.

### DIFF
--- a/src/arch-x86_64/gdt.cpp
+++ b/src/arch-x86_64/gdt.cpp
@@ -1,0 +1,16 @@
+
+#include "gdt.h"
+namespace Hjert::Arch::x86_64 {
+static Gdt _gdt = Gdt{};
+
+static GdtDesc _gdt_desc = GdtDesc{
+    sizeof(Gdt) - 1,
+    &_gdt,
+};
+
+extern "C" void gdtUpdate(void *ptr);
+
+void gdtInitialize() {
+    gdtUpdate(&_gdt_desc);
+}
+} // namespace Hjert::Arch::x86_64

--- a/src/arch-x86_64/gdt.h
+++ b/src/arch-x86_64/gdt.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <karm-base/enum.h>
+#include <karm-base/result.h>
+#include <karm-base/string.h>
+
+namespace Hjert::Arch::x86_64 {
+
+struct [[gnu::packed]] GdtEntry {
+    uint16_t _limit_0_15;
+    uint16_t _base_0_15;
+    uint8_t _base_16_23;
+    uint8_t _flags;
+    uint8_t _limit_16_19 : 4;
+    uint8_t _granularity : 4;
+    uint8_t _base_24_31;
+
+    constexpr GdtEntry(){};
+    constexpr GdtEntry(uint32_t base, uint32_t limit, uint8_t granularity, uint8_t flags)
+        : _limit_0_15(limit & 0xffff),
+          _base_0_15(base & 0xffff),
+          _base_16_23((base >> 16) & 0xff),
+          _flags(flags),
+          _limit_16_19((limit >> 16) & 0x0f),
+          _granularity(granularity),
+          _base_24_31((base >> 24) & 0xff) {}
+
+    constexpr GdtEntry(uint8_t flags, uint8_t granularity) : _flags(flags), _granularity(granularity){};
+};
+
+struct [[gnu::packed]] Gdt {
+    static constexpr int entry_count = 5;
+
+    enum Section {
+        KERNEL_CODE = 1,
+        KERNEL_DATA = 2,
+        USER_DATA = 3,
+        USER_CODE = 4,
+        TSS = 5, /* not implemented */
+    };
+
+    enum Flags : uint32_t {
+        SEGMENT = 0b00010000,
+        PRESENT = 0b10000000,
+        USER = 0b01100000,
+        EXECUTABLE = 0b00001000,
+        READ_WRITE = 0b00000010,
+    };
+
+    enum Granularity {
+        LONG_MODE = 0b10,
+    };
+
+    Karm::Array<GdtEntry, Gdt::entry_count> _entries;
+
+    Gdt() {
+        _entries[0] = GdtEntry(0, 0, 0, 0);
+        _entries[Gdt::KERNEL_CODE] = GdtEntry(Gdt::Flags::PRESENT | Gdt::Flags::SEGMENT | Gdt::Flags::READ_WRITE | Gdt::Flags::EXECUTABLE, Granularity::LONG_MODE);
+        _entries[Gdt::KERNEL_DATA] = GdtEntry(Gdt::Flags::PRESENT | Gdt::Flags::SEGMENT | Gdt::Flags::READ_WRITE, 0);
+
+        _entries[Gdt::USER_DATA] = GdtEntry(Gdt::Flags::PRESENT | Gdt::Flags::SEGMENT | Gdt::Flags::READ_WRITE | Gdt::Flags::USER, 0);
+        _entries[Gdt::USER_CODE] = GdtEntry(Gdt::Flags::PRESENT | Gdt::Flags::SEGMENT | Gdt::Flags::READ_WRITE | Gdt::Flags::EXECUTABLE | Gdt::Flags::USER, Granularity::LONG_MODE);
+    };
+};
+
+struct [[gnu::packed]] GdtDesc {
+
+    uint16_t _limit;
+    uint64_t _base;
+
+    GdtDesc() : _limit(0), _base(0){};
+    GdtDesc(uint16_t limit, Gdt *base) : _limit(limit), _base(reinterpret_cast<uintptr_t>(base)){};
+};
+
+void gdtInitialize();
+
+} // namespace Hjert::Arch::x86_64

--- a/src/arch-x86_64/gdt.s
+++ b/src/arch-x86_64/gdt.s
@@ -1,0 +1,19 @@
+global gdtUpdate
+gdtUpdate:
+  lgdt [rdi]
+  mov ax, 0x10
+  mov ss, ax
+  mov ds, ax
+  mov es, ax
+  mov rax, qword .trampoline
+  push qword 0x8
+  push rax
+  o64 retf
+.trampoline:
+  ret
+
+global tssUpdate
+tssUpdate:
+  mov ax, 0x28
+  ltr ax
+  ret

--- a/src/hjert/entry.cpp
+++ b/src/hjert/entry.cpp
@@ -2,6 +2,8 @@
 #include <hjert/arch.h>
 #include <limine/main.h>
 
+#include <arch-x86_64/gdt.h>
+
 using namespace Hjert;
 
 HandoverRequests$(
@@ -11,6 +13,7 @@ HandoverRequests$(
 
 Error entryPoint([[maybe_unused]] uint64_t magic, [[maybe_unused]] Handover::Payload const &payload) {
     try$(Arch::writeLog("hjert (v0.0.1)\n"));
+    Arch::x86_64::gdtInitialize();
 
     Arch::stopCpu();
 }


### PR DESCRIPTION
Note: this is still WIP, and I know that the code in the entry point should not be responsible for loading the gdt directly.
```c
entryPoint([[maybe_unused]] uint64_t magic, [[maybe_unused]] Handover::Payload const &payload) {
    try$(Arch::writeLog("hjert (v0.0.1)\n"));
    Arch::x86_64::gdtInitialize();

    Arch::stopCpu();
}
```
Sorry for the ugly c++ code :sweat_smile:.